### PR TITLE
adding logging when Hipchat returns non-2xx HTTP status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ export PUPPETFILE_GIT_URL="git@github.com:_org_/puppetfile.git"
 
 ##### REAKTOR_HIPCHAT_TOKEN (required if using hipchat)
 
-auth token to enable posting hipchat messages
+auth token to enable posting hipchat messages. this cannot be a 'notification' token, as reaktor needs to be able to get a room list.
 
 ##### REAKTOR_HIPCHAT_ROOM (required if using hipchat)
 

--- a/lib/reaktor/notification/active_notifiers/hipchat.rb
+++ b/lib/reaktor/notification/active_notifiers/hipchat.rb
@@ -44,6 +44,10 @@ module Notifiers
 
     def room_exist?(room_name)
       rooms = @hipchat.rooms_list
+      if rooms['error'] and rooms['error']['code'] !~ /^2\d+/
+        @logger.error "#{rooms['error']['code']} - #{rooms['error']['message']}"
+        false
+      end
       room = rooms['rooms'].select { |x| x['name'] == room_name }
       @logger.info("room = #{room}")
       room.empty? ? false : true


### PR DESCRIPTION
This small change logs an error if the hipchat user doesn't have access to list rooms. Also a slight clarification to the documentation about the type of API token the Hipchat integration requires.

The more complete solution would be to use Hipchat's v2 API, which adds the ability to verify whether or not a user has access to a method (See the "Testing a token" section at https://www.hipchat.com/docs/apiv2/auth). Until the hipchat-api or hipchat-rb gems support v2 we can't easily implement this.