### PR TITLE
Pin versions for old ruby for Centos 6 installs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,13 @@ gem 'resque-retry', '1.1.4'
 gem 'thin', '1.6.2'
 gem 'god', '0.13.4'
 
+# Pin versions for old ruby
+if RUBY_VERSION.to_f < 1.9
+  gem 'highline', '1.6.21'
+  gem 'net-ssh', '2.9.1'
+  gem 'httparty', '0.11.0'
+end
+
 ## gems for hipchat-api
 gem 'hipchat-api', '1.0.6'
 gem 'capistrano', '2.15.5'


### PR DESCRIPTION
I know you probably don't support centos 6 (ruby 1.8.7) but this allows bundle install to work without affecting others.