### PR TITLE
issue #30: fix feature name handling from payloads

### DIFF
--- a/lib/reaktor/utils/github_payload.rb
+++ b/lib/reaktor/utils/github_payload.rb
@@ -22,7 +22,7 @@ module Reaktor
         repo_ref = payload['ref']
         @created = payload['created']
         @deleted = payload['deleted']
-        ref_array = repo_ref.split("/")
+        ref_array = repo_ref.split("/", 3)
         @ref_type = ref_array[1]
         @branch_name = ref_array[2]
       end

--- a/lib/reaktor/utils/gitlab_payload.rb
+++ b/lib/reaktor/utils/gitlab_payload.rb
@@ -22,7 +22,7 @@ module Reaktor
         repo_ref = payload['ref']
         @created = created?(payload['before'])
         @deleted = deleted?(payload['after'])
-        ref_array = repo_ref.split("/")
+        ref_array = repo_ref.split("/", 3)
         @ref_type = ref_array[1]
         @branch_name = ref_array[2]
       end

--- a/lib/reaktor/utils/stash_payload.rb
+++ b/lib/reaktor/utils/stash_payload.rb
@@ -22,7 +22,7 @@ module Reaktor
         repo_ref = payload['refChanges'][0]['refId']
         @created = created?(payload['refChanges'][0]['fromHash'])
         @deleted = deleted?(payload['refChanges'][0]['toHash'])
-        ref_array = repo_ref.split("/")
+        ref_array = repo_ref.split("/", 3)
         @ref_type = ref_array[1]
         @branch_name = ref_array[2]
       end


### PR DESCRIPTION
so that parts after the third "/" in the refs are not stripped.
examples:
- feature/example
- bugfix/issue-example

please note that r10k will automatically normalize all special characters to "_".